### PR TITLE
Prove that barycentric evaluation is correct.

### DIFF
--- a/EthCryptographySpecs/Proofs/Bls/FrZMod.lean
+++ b/EthCryptographySpecs/Proofs/Bls/FrZMod.lean
@@ -1,8 +1,11 @@
 import EthCryptographySpecs.Bls.Fr
+import EthCryptographySpecs.Proofs.Bls.Fr
 import Mathlib.Data.ZMod.Basic
 import Mathlib.Algebra.Field.ZMod
 import Mathlib.NumberTheory.LucasPrimality
 import Mathlib.Tactic.NormNum.Prime
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
 
 /-!
 # Proofs: `Fr` as a Mathlib finite field
@@ -23,10 +26,34 @@ prime via a Lucas certificate (`lucas_primality`): `7` has order
           2508409 · 2529403 · 52437899 · 254760293²
 
 by verifying `7 ^ (r-1) = 1` and `7 ^ ((r-1)/q) ≠ 1` for each prime
-factor `q`. The modular exponentiations are carried out by the kernel
-through `powModAux`, a fuel-based square-and-multiply whose steps are
+factor `q` (`seven_pow_card_sub_one`, `seven_pow_div_prime_ne_one`).
+The modular exponentiations are carried out by the kernel through
+`powModAux`, a fuel-based square-and-multiply whose steps are
 GMP-accelerated `Nat` operations, so the whole certificate checks in
 seconds without `native_decide`.
+
+The same two facts pin down the multiplicative order of `7` exactly
+(`orderOf_seven`), making `7` a primitive `(r-1)`-th root of unity and
+`7 ^ ((r-1)/n)` a primitive `n`-th root of unity for every `n ∣ r - 1`
+(`isPrimitiveRoot_seven_pow`) — the algebraic backbone of the FFT and
+barycentric-evaluation domains.
+
+## Bridge layer
+
+The last section relates every arithmetic operation the executable spec
+defines on `Fr` to its Mathlib counterpart: `Fr.ofNat` is `Nat.cast`,
+`Fr.powNat` is monoid `^`, `Fr.inverse` is field `⁻¹` (by Fermat's
+little theorem, using primality), and spec division is `a * b⁻¹`.
+The `Field Fr` instance is `Field (ZMod Fr.modulus)` with one change:
+its `Div` data is the spec's own division (`Bls/Fr.lean` registers a
+high-priority Fermat-inverse `Div Fr`), so `a / b` written anywhere in
+the spec *is* the field's division — copying ZMod's gcd-based division
+data instead would leave two propositionally-but-not-definitionally
+equal `Div Fr` instances in scope, and the kernel rejects the resulting
+structure. Downstream proofs activate the field structure with
+`open scoped EthCryptographySpecs.Bls.Fr` — it is scoped, not global,
+for the same reason Mathlib keeps `Fin.instCommRing` scoped (see the
+note in `Mathlib.Data.ZMod.Defs` about coercion loops).
 -/
 
 namespace EthCryptographySpecs.Bls.Fr
@@ -34,6 +61,18 @@ namespace EthCryptographySpecs.Bls.Fr
 -- Kernel evaluation of `powModAux` (256 recursion steps) exceeds the
 -- default `maxRecDepth` of the `decide` calls below.
 set_option maxRecDepth 4000
+
+-- Core registers a global `HPow (Fin n) Nat (Fin n)` (and its `Pow`)
+-- for the `grind` tactic. Because `Fr` is an abbrev of `Fin modulus`,
+-- `a ^ n` with a `Nat` exponent elaborates through that instance
+-- instead of Mathlib's `Monoid.toPow` — the two are definitionally but
+-- not syntactically equal, so `rw` with Mathlib's `pow` lemmas fails
+-- against statements phrased with the grind instance. Remove them for
+-- this file so every `Fr ^ Nat` below is Mathlib's monoid power.
+-- NOTE: `attribute [-instance]` is file-local; proof files that state
+-- `Fr ^ Nat` lemmas must repeat these two lines.
+attribute [-instance] Lean.Grind.Fin.instHPowFinNatOfNeZero
+attribute [-instance] Lean.Grind.Fin.instPowFinNatOfNeZero
 
 /-- Fuel-based modular square-and-multiply: `powModAux fuel m b e` is
 `b ^ e % m` provided `e < 2 ^ fuel`. Structural recursion on `fuel`
@@ -80,55 +119,65 @@ private theorem seven_pow_div_ne_one (q : Nat)
   fun h => hne ((natCast_pow_eq_one_iff 7 _
     (Nat.lt_of_le_of_lt (Nat.div_le_self _ _) (by decide))).mp h)
 
+/-- First half of the Lucas certificate: `7 ^ (r - 1) = 1` in `ZMod r`. -/
+theorem seven_pow_card_sub_one : ((7 : ℕ) : ZMod modulus) ^ (modulus - 1) = 1 := by
+  rw [natCast_pow_eq_one_iff 7 (modulus - 1) (by decide)]
+  decide
+
+/-- Second half of the Lucas certificate: `7 ^ ((r - 1) / q) ≠ 1` in
+`ZMod r` for every prime factor `q` of `r - 1`. Together with
+`seven_pow_card_sub_one` this pins the order of `7` to exactly `r - 1`. -/
+theorem seven_pow_div_prime_ne_one : ∀ q : Nat, q.Prime → q ∣ modulus - 1 →
+    ((7 : ℕ) : ZMod modulus) ^ ((modulus - 1) / q) ≠ 1 := by
+  intro q hq hdvd
+  have heq : ∀ p : Nat, p.Prime → q ∣ p → q = p := fun p hp h =>
+    (Nat.prime_dvd_prime_iff_eq hq hp).mp h
+  have hfact : modulus - 1 =
+      2 ^ 32 * (3 * (11 * (19 * (10177 * (125527 * (859267 * (906349 ^ 2 *
+        (2508409 * (2529403 * (52437899 * 254760293 ^ 2)))))))))) := by decide
+  rw [hfact] at hdvd
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 2 Nat.prime_two (hq.dvd_of_dvd_pow h)
+    exact seven_pow_div_ne_one 2 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 3 (by norm_num) h
+    exact seven_pow_div_ne_one 3 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 11 (by norm_num) h
+    exact seven_pow_div_ne_one 11 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 19 (by norm_num) h
+    exact seven_pow_div_ne_one 19 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 10177 (by norm_num) h
+    exact seven_pow_div_ne_one 10177 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 125527 (by norm_num) h
+    exact seven_pow_div_ne_one 125527 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 859267 (by norm_num) h
+    exact seven_pow_div_ne_one 859267 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 906349 (by norm_num) (hq.dvd_of_dvd_pow h)
+    exact seven_pow_div_ne_one 906349 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 2508409 (by norm_num) h
+    exact seven_pow_div_ne_one 2508409 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 2529403 (by norm_num) h
+    exact seven_pow_div_ne_one 2529403 (by decide)
+  rcases (hq.dvd_mul).mp hdvd with h | hdvd
+  · obtain rfl := heq 52437899 (by norm_num) h
+    exact seven_pow_div_ne_one 52437899 (by decide)
+  · obtain rfl := heq 254760293 (by norm_num) (hq.dvd_of_dvd_pow hdvd)
+    exact seven_pow_div_ne_one 254760293 (by decide)
+
 /-- The BLS12-381 scalar field modulus is prime, by a Lucas primality
 certificate with witness `7` (a primitive root mod `r`, the same
 generator the consensus specs use for roots of unity). -/
-theorem modulus_prime : Nat.Prime modulus := by
-  refine lucas_primality modulus ((7 : ℕ) : ZMod modulus) ?_ ?_
-  · rw [natCast_pow_eq_one_iff 7 (modulus - 1) (by decide)]
-    decide
-  · intro q hq hdvd
-    have heq : ∀ p : Nat, p.Prime → q ∣ p → q = p := fun p hp h =>
-      (Nat.prime_dvd_prime_iff_eq hq hp).mp h
-    have hfact : modulus - 1 =
-        2 ^ 32 * (3 * (11 * (19 * (10177 * (125527 * (859267 * (906349 ^ 2 *
-          (2508409 * (2529403 * (52437899 * 254760293 ^ 2)))))))))) := by decide
-    rw [hfact] at hdvd
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 2 Nat.prime_two (hq.dvd_of_dvd_pow h)
-      exact seven_pow_div_ne_one 2 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 3 (by norm_num) h
-      exact seven_pow_div_ne_one 3 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 11 (by norm_num) h
-      exact seven_pow_div_ne_one 11 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 19 (by norm_num) h
-      exact seven_pow_div_ne_one 19 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 10177 (by norm_num) h
-      exact seven_pow_div_ne_one 10177 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 125527 (by norm_num) h
-      exact seven_pow_div_ne_one 125527 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 859267 (by norm_num) h
-      exact seven_pow_div_ne_one 859267 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 906349 (by norm_num) (hq.dvd_of_dvd_pow h)
-      exact seven_pow_div_ne_one 906349 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 2508409 (by norm_num) h
-      exact seven_pow_div_ne_one 2508409 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 2529403 (by norm_num) h
-      exact seven_pow_div_ne_one 2529403 (by decide)
-    rcases (hq.dvd_mul).mp hdvd with h | hdvd
-    · obtain rfl := heq 52437899 (by norm_num) h
-      exact seven_pow_div_ne_one 52437899 (by decide)
-    · obtain rfl := heq 254760293 (by norm_num) (hq.dvd_of_dvd_pow hdvd)
-      exact seven_pow_div_ne_one 254760293 (by decide)
+theorem modulus_prime : Nat.Prime modulus :=
+  lucas_primality modulus ((7 : ℕ) : ZMod modulus)
+    seven_pow_card_sub_one seven_pow_div_prime_ne_one
 
 instance : Fact (Nat.Prime modulus) := ⟨modulus_prime⟩
 
@@ -136,9 +185,153 @@ instance : Fact (Nat.Prime modulus) := ⟨modulus_prime⟩
 def toZMod : Fr ≃+* ZMod modulus := RingEquiv.refl _
 
 /-- With primality, `ZMod Fr.modulus` — and hence `Fr`, via `toZMod` —
-is a finite field. (Not registered as a global `Field Fr` instance:
-Mathlib's field division would clash with the spec's `Div Fr`
-instance.) -/
+is a finite field. (See `Fr.instField` below for the scoped instance.) -/
 example : Field (ZMod modulus) := inferInstance
+
+/-! ## Roots of unity -/
+
+/-- `7` has multiplicative order exactly `r - 1` in `ZMod r`: it is a
+generator of the multiplicative group. Reuses the two halves of the
+Lucas certificate. -/
+theorem orderOf_seven : orderOf ((7 : ℕ) : ZMod modulus) = modulus - 1 :=
+  orderOf_eq_of_pow_and_pow_div_prime (by decide)
+    seven_pow_card_sub_one seven_pow_div_prime_ne_one
+
+/-- `7` is a primitive `(r-1)`-th root of unity in `ZMod r`. -/
+theorem isPrimitiveRoot_seven :
+    IsPrimitiveRoot ((7 : ℕ) : ZMod modulus) (modulus - 1) :=
+  orderOf_seven ▸ IsPrimitiveRoot.orderOf _
+
+/-- `7 ^ ((r-1)/n)` is a primitive `n`-th root of unity for every
+`n ∣ r - 1`. This is the root the KZG spec's `computeRootsOfUnity`
+builds its evaluation domains from. -/
+theorem isPrimitiveRoot_seven_pow {n : Nat} (hn : n ∣ modulus - 1) :
+    IsPrimitiveRoot (((7 : ℕ) : ZMod modulus) ^ ((modulus - 1) / n)) n :=
+  isPrimitiveRoot_seven.pow (by decide) (Nat.div_mul_cancel hn).symm
+
+/-! ## Bridge: spec operations = Mathlib operations -/
+
+/-- `Fr.powNat` is monoid power, phrased over `ZMod Fr.modulus`
+(definitionally `Fr`) so it is usable while constructing `Fr`'s own
+`Field` instance below. Public `Fr`-facing version: `powNat_eq_pow`. -/
+private theorem powNat_eq_zmod_pow (a : ZMod modulus) (n : Nat) :
+    Fr.powNat a n = a ^ n := by
+  induction n with
+  | zero => rw [powNat_zero, pow_zero]; rfl
+  | succ n ih => rw [powNat_succ, ih, pow_succ']; rfl
+
+/-- The spec's Fermat-little-theorem `Fr.inverse` is the field inverse
+of `ZMod Fr.modulus` (both send `0` to `0`), phrased over
+`ZMod Fr.modulus` for the same reason as `powNat_eq_zmod_pow`. Public
+`Fr`-facing version: `inverse_eq_inv`. -/
+private theorem inverse_eq_zmod_inv (a : ZMod modulus) :
+    Fr.inverse a = a⁻¹ := by
+  rw [inverse, powNat_eq_zmod_pow]
+  by_cases h : a = 0
+  · subst h
+    rw [zero_pow (by decide : modulus - 2 ≠ 0), inv_zero]
+  · have h2 : a ^ (modulus - 2) * a = 1 := by
+      rw [← pow_succ, show modulus - 2 + 1 = modulus - 1 by decide]
+      exact ZMod.pow_card_sub_one_eq_one h
+    exact eq_inv_of_mul_eq_one_left h2
+
+/-- The Mathlib field structure on `ZMod Fr.modulus`, named so it can be
+used as the source of the structure update in `instField` below. -/
+@[reducible] private def zmodField : Field (ZMod modulus) := inferInstance
+
+/-- Field structure on `Fr`, transported from `Field (ZMod Fr.modulus)`
+with one change: the `Div` data is the spec's own high-priority
+Fermat-inverse division from `Bls/Fr.lean`, so that `a / b` written
+anywhere in the spec is definitionally the field's division. (Copying
+ZMod's gcd-based division data instead makes the kernel reject the
+instance: the `div`-mentioning axioms would be stated with the spec's
+`Div Fr` but proved for ZMod's.) The three axioms whose statements
+mention `/` are re-proved via `inverse_eq_zmod_inv` — phrased over
+`ZMod Fr.modulus`, where all instances exist, and handed over by
+definitional equality; all other data and proofs are ZMod's.
+
+Scoped rather than global for the same reason Mathlib keeps
+`Fin.instCommRing` scoped (see `Mathlib.Data.ZMod.Defs`): the `NatCast`
+coercion it introduces can change how mixed `Fin`/`Nat` expressions
+elaborate. Activate with `open scoped EthCryptographySpecs.Bls.Fr`. -/
+scoped instance instField : Field Fr :=
+  { zmodField with
+    div := (· / ·)
+    div_eq_mul_inv := fun a b =>
+      -- Explicit `@HMul.hMul` because `a * ·` would make the binop
+      -- elaborator look for `HMul (ZMod modulus) Fr` on the mixed-type
+      -- operands; the defeq handover to the goal is checked by `exact`.
+      congrArg (fun x : ZMod modulus =>
+          @HMul.hMul (ZMod modulus) (ZMod modulus) (ZMod modulus) _ a x)
+        (inverse_eq_zmod_inv b)
+    nnratCast_def := fun q => by
+      have h : (q : ZMod modulus)
+          = (q.num : ZMod modulus) / (q.den : ZMod modulus) := NNRat.cast_def q
+      rw [div_eq_mul_inv, ← inverse_eq_zmod_inv] at h
+      exact h
+    ratCast_def := fun q => by
+      have h : (q : ZMod modulus)
+          = (q.num : ZMod modulus) / (q.den : ZMod modulus) := Rat.cast_def q
+      rw [div_eq_mul_inv, ← inverse_eq_zmod_inv] at h
+      exact h }
+
+@[simp] theorem zero_def : Fr.zero = (0 : Fr) := rfl
+
+@[simp] theorem one_def : Fr.one = (1 : Fr) := rfl
+
+/-- The spec's `Fr.ofNat` is Mathlib's `Nat.cast`. -/
+theorem ofNat_eq_natCast (n : Nat) : Fr.ofNat n = (n : Fr) := by
+  apply Fin.ext
+  rw [ofNat, Fin.val_ofNat]
+  exact (ZMod.val_natCast modulus n).symm
+
+/-- The spec's `Fr.powNat` is Mathlib's monoid power. -/
+theorem powNat_eq_pow (a : Fr) (n : Nat) : a.powNat n = a ^ n :=
+  powNat_eq_zmod_pow a n
+
+/-- The spec's `HPow Fr Fr Fr` (used as `a ^ b`) is Mathlib's monoid
+power at the exponent's value. -/
+theorem hpow_eq_pow (a b : Fr) : a ^ b = a ^ b.val :=
+  powNat_eq_pow a b.val
+
+/-- Specialization of `hpow_eq_pow` to an `ofNat`-embedded exponent:
+when `w` is canonical the round-trip through `Fr` is invisible. -/
+theorem hpow_ofNat_eq_pow (a : Fr) {w : Nat} (hw : w < modulus) :
+    a ^ Fr.ofNat w = a ^ w := by
+  rw [hpow_eq_pow]
+  congr 1
+  show w % modulus = w
+  exact Nat.mod_eq_of_lt hw
+
+/-- The spec's Fermat-little-theorem `Fr.inverse` is the field inverse.
+Both send `0` to `0`. -/
+theorem inverse_eq_inv (a : Fr) : a.inverse = a⁻¹ :=
+  inverse_eq_zmod_inv a
+
+/-- The spec's division (`a * b.inverse`, registered at high priority
+over core's `Fin` Nat-division) is field division. -/
+theorem div_eq_mul_inv' (a b : Fr) : a / b = a * b⁻¹ := by
+  show a * b.inverse = a * b⁻¹
+  rw [inverse_eq_inv]
+
+/-- `Fr`-facing form of `isPrimitiveRoot_seven_pow`, phrased with the
+spec's own operations (`Fr.ofNat` and the `Fr`-exponent power): the root
+`computeRootsOfUnity n` starts from is a primitive `n`-th root of
+unity. -/
+theorem isPrimitiveRoot_ofNat_seven_pow {n : Nat} (hn : n ∣ modulus - 1) :
+    IsPrimitiveRoot (Fr.ofNat 7 ^ Fr.ofNat ((modulus - 1) / n)) n := by
+  have hlt : (modulus - 1) / n < modulus :=
+    Nat.lt_of_le_of_lt (Nat.div_le_self _ _) (Nat.sub_lt Fr.modulus_pos Nat.one_pos)
+  have hval : (Fr.ofNat ((modulus - 1) / n)).val = (modulus - 1) / n := by
+    rw [ofNat, Fin.val_ofNat]
+    exact Nat.mod_eq_of_lt hlt
+  rw [hpow_eq_pow, hval, ofNat_eq_natCast]
+  exact isPrimitiveRoot_seven_pow hn
+
+-- Smoke tests: the scoped field structure interoperates with the
+-- globally available `Fin` instances the executable spec uses.
+example (a b : Fr) : a * b = b * a := mul_comm a b
+example (a b : Fr) : a - b = a + -b := sub_eq_add_neg a b
+example (a : Fr) (h : a ≠ 0) : a * a⁻¹ = 1 := mul_inv_cancel₀ h
 
 end EthCryptographySpecs.Bls.Fr

--- a/EthCryptographySpecs/Proofs/Kzg.lean
+++ b/EthCryptographySpecs/Proofs/Kzg.lean
@@ -1,3 +1,4 @@
+import EthCryptographySpecs.Proofs.Kzg.Barycentric
 import EthCryptographySpecs.Proofs.Kzg.BitReversal
 import EthCryptographySpecs.Proofs.Kzg.Domain
 import EthCryptographySpecs.Proofs.Kzg.Fft

--- a/EthCryptographySpecs/Proofs/Kzg.lean
+++ b/EthCryptographySpecs/Proofs/Kzg.lean
@@ -1,6 +1,7 @@
 import EthCryptographySpecs.Proofs.Kzg.Barycentric
 import EthCryptographySpecs.Proofs.Kzg.BitReversal
 import EthCryptographySpecs.Proofs.Kzg.Domain
+import EthCryptographySpecs.Proofs.Kzg.Evaluation
 import EthCryptographySpecs.Proofs.Kzg.Fft
 import EthCryptographySpecs.Proofs.Kzg.Polynomials
 import EthCryptographySpecs.Proofs.Kzg.Core

--- a/EthCryptographySpecs/Proofs/Kzg.lean
+++ b/EthCryptographySpecs/Proofs/Kzg.lean
@@ -1,4 +1,5 @@
 import EthCryptographySpecs.Proofs.Kzg.BitReversal
+import EthCryptographySpecs.Proofs.Kzg.Domain
 import EthCryptographySpecs.Proofs.Kzg.Fft
 import EthCryptographySpecs.Proofs.Kzg.Polynomials
 import EthCryptographySpecs.Proofs.Kzg.Core

--- a/EthCryptographySpecs/Proofs/Kzg/Barycentric.lean
+++ b/EthCryptographySpecs/Proofs/Kzg/Barycentric.lean
@@ -1,0 +1,92 @@
+import EthCryptographySpecs.Proofs.Kzg.Polynomials
+import EthCryptographySpecs.Proofs.Bls.FrZMod
+import Mathlib.Algebra.BigOperators.Intervals
+
+/-!
+# Proofs: barycentric evaluation in Mathlib form
+
+Restates the slow (barycentric) path of
+`evaluatePolynomialInEvaluationForm` purely in Mathlib operations:
+the fold `barycentricRefSum` becomes a `Finset.sum`
+(`barycentricRefSum_eq_sum`), the spec's `Fr`-exponent power and
+Fermat inverse become monoid power and field inverse, and the width
+constant becomes a `Nat.cast`. The result,
+`evaluatePolynomialInEvaluationForm_slowPath_sum`, is the form the
+Lagrange-interpolation argument consumes.
+
+Uses the scoped `Field Fr` instance from `Proofs.Bls.FrZMod`.
+-/
+
+namespace EthCryptographySpecs.Kzg
+
+open EthCryptographySpecs.Bls (Fr)
+open EthCryptographySpecs.Kzg.Constants
+open scoped EthCryptographySpecs.Bls.Fr
+
+-- See the note in `Proofs.Bls.FrZMod`: core's grind-tactic `HPow`
+-- instance on `Fin` shadows Mathlib's monoid power on `Fr` and breaks
+-- `rw` with Mathlib `pow` lemmas. File-local, so repeated here.
+attribute [-instance] Lean.Grind.Fin.instHPowFinNatOfNeZero
+attribute [-instance] Lean.Grind.Fin.instPowFinNatOfNeZero
+
+/-- The barycentric sum as a `Finset.sum`, with the spec's division. -/
+theorem barycentricRefSum_eq_sum_div (p D : Array Fr) (z : Fr) (n : Nat) :
+    barycentricRefSum p D z n
+      = ∑ i ∈ Finset.range n, p[i]! * D[i]! / (z - D[i]!) := by
+  induction n with
+  | zero => simp [barycentricRefSum]
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih]
+    show barycentricRefSum p D z n + _ = _
+    rfl
+
+/-- The barycentric sum as a `Finset.sum` over field operations only
+(spec division unfolded to `* _⁻¹` via little Fermat). -/
+theorem barycentricRefSum_eq_sum (p D : Array Fr) (z : Fr) (n : Nat) :
+    barycentricRefSum p D z n
+      = ∑ i ∈ Finset.range n, p[i]! * D[i]! * (z - D[i]!)⁻¹ := by
+  rw [barycentricRefSum_eq_sum_div]
+  exact Finset.sum_congr rfl fun i _ => Bls.Fr.div_eq_mul_inv' _ _
+
+/-- The blob width is nonzero in `Fr` (it is `4096`, far below `r`), so
+dividing by it in the barycentric formula is meaningful. -/
+theorem natCast_field_elements_per_blob_ne_zero :
+    ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr) ≠ 0 := by
+  rw [← Bls.Fr.ofNat_eq_natCast]
+  decide
+
+/-- Slow path of `evaluatePolynomialInEvaluationFormAux` in Mathlib
+operations. Needs the width to be canonical (`p.size < r`) so the
+spec's detour of the exponent through `Fr` is invisible. -/
+theorem evaluatePolynomialInEvaluationFormAux_slowPath_sum
+    (p D : Array Fr) (z : Fr) (hw : p.size < Fr.modulus)
+    (h : D.idxOf? z = none) :
+    evaluatePolynomialInEvaluationFormAux p D z =
+      (∑ i ∈ Finset.range p.size, p[i]! * D[i]! * (z - D[i]!)⁻¹)
+        * (z ^ p.size - 1) * ((p.size : Nat) : Fr)⁻¹ := by
+  rw [evaluatePolynomialInEvaluationFormAux_slowPath p D z h,
+      barycentricRefSum_eq_sum, Bls.Fr.hpow_ofNat_eq_pow z hw,
+      Bls.Fr.inverse_eq_inv, Bls.Fr.ofNat_eq_natCast, Bls.Fr.one_def]
+
+/-- Slow path of `evaluatePolynomialInEvaluationForm` in Mathlib
+operations: for a full-width polynomial and `z` outside the domain,
+
+  `f(z) = (Σ_i p[i]·D[i]/(z − D[i])) · (z^4096 − 1) / 4096`
+
+with `D` the bit-reversed 4096th roots of unity. -/
+theorem evaluatePolynomialInEvaluationForm_slowPath_sum
+    (p : Polynomial) (z : Fr) (hsize : p.size = FIELD_ELEMENTS_PER_BLOB)
+    (h : (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB).idxOf? z = none) :
+    evaluatePolynomialInEvaluationForm p z =
+      (∑ i ∈ Finset.range FIELD_ELEMENTS_PER_BLOB,
+          p[i]! * (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!
+            * (z - (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!)⁻¹)
+        * (z ^ FIELD_ELEMENTS_PER_BLOB - 1)
+        * ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr)⁻¹ := by
+  have hw : p.size < Fr.modulus := by rw [hsize]; decide
+  have := evaluatePolynomialInEvaluationFormAux_slowPath_sum p
+    (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB) z hw h
+  rw [hsize] at this
+  exact this
+
+end EthCryptographySpecs.Kzg

--- a/EthCryptographySpecs/Proofs/Kzg/Domain.lean
+++ b/EthCryptographySpecs/Proofs/Kzg/Domain.lean
@@ -1,0 +1,159 @@
+import EthCryptographySpecs.Kzg.Polynomials
+import EthCryptographySpecs.Proofs.Bls.FrZMod
+import EthCryptographySpecs.Proofs.Kzg.BitReversal
+import EthCryptographySpecs.Proofs.Kzg.Polynomials
+import Batteries.Data.Array.Lemmas
+
+/-!
+# Proofs: the roots-of-unity evaluation domain
+
+Characterizes `rootsOfUnityBrp n` for power-of-two `n` dividing
+`r - 1`: element `i` is `ω ^ reverseBits i n` for `ω` a primitive
+`n`-th root of unity (`domainRoot`), the elements are pairwise
+distinct, and membership is exactly "is an `n`-th root of unity"
+(`mem_rootsOfUnityBrp`). The `idxOf?` bridges translate the two
+branches of `evaluatePolynomialInEvaluationFormAux` into algebra:
+a hit pins down `z` as a domain element, and a miss means
+`z ^ n ≠ 1` — in particular no barycentric denominator `z - D[i]`
+vanishes (`sub_getElem_ne_zero_of_idxOf?_eq_none`).
+
+Uses the scoped `Field Fr` instance from `Proofs.Bls.FrZMod`.
+-/
+
+namespace EthCryptographySpecs.Kzg
+
+open EthCryptographySpecs.Bls (Fr)
+open EthCryptographySpecs.Kzg.Constants
+open EthCryptographySpecs.Kzg.BitReversal
+open scoped EthCryptographySpecs.Bls.Fr
+
+-- See the note in `Proofs.Bls.FrZMod`: core's grind-tactic `HPow`
+-- instance on `Fin` shadows Mathlib's monoid power on `Fr` and breaks
+-- `rw` with Mathlib `pow` lemmas. File-local, so repeated here.
+attribute [-instance] Lean.Grind.Fin.instHPowFinNatOfNeZero
+attribute [-instance] Lean.Grind.Fin.instPowFinNatOfNeZero
+
+/-- The blob width is the power of two the bit-reversal lemmas expect. -/
+theorem field_elements_per_blob_eq_two_pow :
+    FIELD_ELEMENTS_PER_BLOB = 2 ^ 12 := rfl
+
+/-- The blob width divides `r - 1`, so a primitive
+`FIELD_ELEMENTS_PER_BLOB`-th root of unity exists. -/
+theorem field_elements_per_blob_dvd_modulus_sub_one :
+    FIELD_ELEMENTS_PER_BLOB ∣ BLS_MODULUS - 1 :=
+  Nat.dvd_of_mod_eq_zero (by decide)
+
+/-- The root of unity `computeRootsOfUnity order` builds its powers
+from: `7 ^ ((r - 1) / order)`. -/
+def domainRoot (order : Nat) : Fr :=
+  Fr.ofNat PRIMITIVE_ROOT_OF_UNITY ^ Fr.ofNat ((BLS_MODULUS - 1) / order)
+
+/-- `domainRoot order` is a primitive `order`-th root of unity whenever
+`order ∣ r - 1`. -/
+theorem isPrimitiveRoot_domainRoot {order : Nat}
+    (h : order ∣ BLS_MODULUS - 1) :
+    IsPrimitiveRoot (domainRoot order) order :=
+  Bls.Fr.isPrimitiveRoot_ofNat_seven_pow h
+
+/-- `computeRootsOfUnity order` lists the powers of `domainRoot order`
+in order: element `i` is `ω ^ i`. -/
+theorem getElem_computeRootsOfUnity (order i : Nat)
+    (h : i < (computeRootsOfUnity order).size) :
+    (computeRootsOfUnity order)[i] = domainRoot order ^ i := by
+  show (computePowers (domainRoot order) order)[i] = _
+  rw [getElem_computePowers]
+  exact Bls.Fr.powNat_eq_pow _ _
+
+/-- Element `i` of the bit-reversed domain is `ω ^ reverseBits i n`.
+The power-of-two hypothesis is phrased as an equation so the lemma
+applies directly to width constants like `FIELD_ELEMENTS_PER_BLOB`
+(with `hnk := field_elements_per_blob_eq_two_pow`). -/
+theorem getElem_rootsOfUnityBrp {n k : Nat} (hnk : n = 2 ^ k) (i : Nat)
+    (h : i < (rootsOfUnityBrp n).size) :
+    (rootsOfUnityBrp n)[i] = domainRoot n ^ reverseBits i n := by
+  subst hnk
+  have hrev : reverseBits i (2 ^ k) < (computeRootsOfUnity (2 ^ k)).size := by
+    rw [size_computeRootsOfUnity]
+    exact reverseBits_lt_two_pow i k
+  have hsize : i < (bitReversalPermutation (computeRootsOfUnity (2 ^ k))).size := h
+  show (bitReversalPermutation (computeRootsOfUnity (2 ^ k)))[i] = _
+  rw [getElem_bitReversalPermutation, size_computeRootsOfUnity,
+      getElem!_pos (computeRootsOfUnity (2 ^ k)) (reverseBits i (2 ^ k)) hrev,
+      getElem_computeRootsOfUnity]
+
+/-- The bit-reversed domain has no repeated elements. -/
+theorem getElem_rootsOfUnityBrp_inj {n k : Nat} (hnk : n = 2 ^ k)
+    (hdvd : n ∣ BLS_MODULUS - 1) {i j : Nat}
+    (hi : i < n) (hj : j < n)
+    (h : (rootsOfUnityBrp n)[i]! = (rootsOfUnityBrp n)[j]!) :
+    i = j := by
+  subst hnk
+  have hsi : i < (rootsOfUnityBrp (2 ^ k)).size := by
+    rwa [size_rootsOfUnityBrp]
+  have hsj : j < (rootsOfUnityBrp (2 ^ k)).size := by
+    rwa [size_rootsOfUnityBrp]
+  rw [getElem!_pos (rootsOfUnityBrp (2 ^ k)) i hsi,
+      getElem!_pos (rootsOfUnityBrp (2 ^ k)) j hsj,
+      getElem_rootsOfUnityBrp rfl, getElem_rootsOfUnityBrp rfl] at h
+  have hrev := (isPrimitiveRoot_domainRoot hdvd).pow_inj
+    (reverseBits_lt_two_pow i k) (reverseBits_lt_two_pow j k) h
+  have := congrArg (reverseBits · (2 ^ k)) hrev
+  simpa [reverseBits_reverseBits hi, reverseBits_reverseBits hj] using this
+
+/-- The bit-reversed domain enumerates exactly the `2 ^ k`-th roots of
+unity: `z` occurs in it iff `z ^ (2 ^ k) = 1`. -/
+theorem mem_rootsOfUnityBrp {n k : Nat} (hnk : n = 2 ^ k)
+    (hdvd : n ∣ BLS_MODULUS - 1) (z : Fr) :
+    z ∈ rootsOfUnityBrp n ↔ z ^ n = 1 := by
+  subst hnk
+  have hprim := isPrimitiveRoot_domainRoot hdvd
+  constructor
+  · intro hz
+    obtain ⟨i, hi, rfl⟩ := Array.mem_iff_getElem.mp hz
+    -- Restated `have`s pin Mathlib facts to this goal's instance path
+    -- so the `rw`s below match (see the elaboration notes in the plan).
+    have hone : domainRoot (2 ^ k) ^ 2 ^ k = 1 := hprim.pow_eq_one
+    rw [getElem_rootsOfUnityBrp rfl i hi, ← pow_mul, Nat.mul_comm, pow_mul,
+        hone]
+    exact one_pow _
+  · intro hz
+    have : NeZero (2 ^ k) := ⟨(Nat.two_pow_pos k).ne'⟩
+    obtain ⟨i, hik, hi⟩ := hprim.eq_pow_of_pow_eq_one hz
+    refine Array.mem_iff_getElem.mpr ⟨reverseBits i (2 ^ k), ?_, ?_⟩
+    · rw [size_rootsOfUnityBrp]
+      exact reverseBits_lt_two_pow i k
+    · rw [getElem_rootsOfUnityBrp rfl, reverseBits_reverseBits hik]
+      exact hi
+
+/-- A domain hit locates `z`: if `idxOf?` answers `some i`, then `i` is
+in range and `z` is element `i` of the domain. Generic in the domain
+size (no power-of-two hypothesis needed). -/
+theorem idxOf?_rootsOfUnityBrp_eq_some {n : Nat} {z : Fr} {i : Nat}
+    (h : (rootsOfUnityBrp n).idxOf? z = some i) :
+    i < n ∧ (rootsOfUnityBrp n)[i]! = z := by
+  rw [← Array.idxOf?_toList] at h
+  obtain ⟨hlen, heq, -⟩ := List.idxOf?_eq_some_iff.mp h
+  have hsize : i < (rootsOfUnityBrp n).size := by simpa using hlen
+  refine ⟨by simpa using hsize, ?_⟩
+  rw [getElem!_pos (rootsOfUnityBrp n) i hsize]
+  simpa using heq
+
+/-- A domain miss means `z` is not an `n`-th root of unity. -/
+theorem pow_ne_one_of_idxOf?_eq_none {n k : Nat} (hnk : n = 2 ^ k)
+    (hdvd : n ∣ BLS_MODULUS - 1) {z : Fr}
+    (h : (rootsOfUnityBrp n).idxOf? z = none) :
+    z ^ n ≠ 1 := fun hpow =>
+  Array.idxOf?_eq_none_iff.mp h ((mem_rootsOfUnityBrp hnk hdvd z).mpr hpow)
+
+/-- On a domain miss, no barycentric denominator vanishes:
+`z - D[i] ≠ 0` for every in-range `i`. Generic in the domain size. -/
+theorem sub_getElem_ne_zero_of_idxOf?_eq_none {n : Nat} {z : Fr}
+    (h : (rootsOfUnityBrp n).idxOf? z = none) {i : Nat} (hi : i < n) :
+    z - (rootsOfUnityBrp n)[i]! ≠ 0 := by
+  have hsi : i < (rootsOfUnityBrp n).size := by rwa [size_rootsOfUnityBrp]
+  have hz : z ∉ rootsOfUnityBrp n := Array.idxOf?_eq_none_iff.mp h
+  rw [getElem!_pos (rootsOfUnityBrp n) i hsi]
+  exact sub_ne_zero_of_ne fun hzeq =>
+    hz (hzeq ▸ Array.mem_iff_getElem.mpr ⟨i, hsi, rfl⟩)
+
+end EthCryptographySpecs.Kzg

--- a/EthCryptographySpecs/Proofs/Kzg/Evaluation.lean
+++ b/EthCryptographySpecs/Proofs/Kzg/Evaluation.lean
@@ -1,0 +1,218 @@
+import EthCryptographySpecs.Proofs.Kzg.Domain
+import EthCryptographySpecs.Proofs.Kzg.Barycentric
+import Mathlib.LinearAlgebra.Lagrange
+
+/-!
+# Proofs: correctness of `evaluatePolynomialInEvaluationForm`
+
+The main results of this file:
+
+* `evaluatePolynomialInEvaluationForm_eq_interpolate`: for a
+  full-width polynomial `p` (in evaluation form over the bit-reversed
+  roots-of-unity domain), `evaluatePolynomialInEvaluationForm p z` is
+  the evaluation at `z` of the Lagrange interpolant of the pairs
+  `(D[i], p[i])`.
+* `evaluatePolynomialInEvaluationForm_eq_eval` (spec voice): if
+  `p[i] = f(D[i])` for a polynomial `f` of degree `< 4096`, the
+  function returns `f(z)` — i.e. it evaluates *the* polynomial of
+  degree `< 4096` determined by the blob, at any point of `Fr`.
+
+The proof splits on `idxOf?`. The fast path is
+`Lagrange.eval_interpolate_at_node`. The slow path is the barycentric
+formula: `Lagrange.eval_interpolate_not_at_node` expresses the
+interpolant's value as `nodal(z) · Σ_i w_i/(z − D[i]) · p[i]`, and on
+our domain the nodal polynomial is `X^4096 − 1` (`nodal_evalDomain`,
+because the domain enumerates exactly the 4096th roots of unity) with
+nodal weights `D[i]/4096` (`nodalWeight_evalDomain`, from the
+derivative `4096·X^4095` and `D[i]^4096 = 1`), which is precisely the
+spec's formula as restated in `Proofs.Kzg.Barycentric`.
+
+Uses the scoped `Field Fr` instance from `Proofs.Bls.FrZMod`.
+-/
+
+namespace EthCryptographySpecs.Kzg
+
+open EthCryptographySpecs.Bls (Fr)
+open EthCryptographySpecs.Kzg.Constants
+open EthCryptographySpecs.Kzg.BitReversal
+open scoped EthCryptographySpecs.Bls.Fr
+open Polynomial
+
+-- See the note in `Proofs.Bls.FrZMod`: core's grind-tactic `HPow`
+-- instance on `Fin` shadows Mathlib's monoid power on `Fr` and breaks
+-- `rw` with Mathlib `pow` lemmas. File-local, so repeated here.
+attribute [-instance] Lean.Grind.Fin.instHPowFinNatOfNeZero
+attribute [-instance] Lean.Grind.Fin.instPowFinNatOfNeZero
+
+-- A few unification problems below (e.g. seeing through
+-- `Lagrange.nodal` to its `Finset.prod`) exceed the default depth.
+set_option maxRecDepth 4000
+
+/-- The evaluation domain as a function on indices, as Mathlib's
+interpolation API expects it: `evalDomain i` is element `i` of the
+bit-reversed 4096th roots of unity. -/
+def evalDomain (i : Fin FIELD_ELEMENTS_PER_BLOB) : Fr :=
+  (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i.val]'
+    (by rw [size_rootsOfUnityBrp]; exact i.isLt)
+
+theorem evalDomain_eq_getElem! (i : Fin FIELD_ELEMENTS_PER_BLOB) :
+    evalDomain i = (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i.val]! := by
+  rw [evalDomain, getElem!_pos (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB) i.val
+    (by rw [size_rootsOfUnityBrp]; exact i.isLt)]
+
+/-- The 4096 domain points are pairwise distinct — the interpolation
+nodes are honest nodes. -/
+theorem evalDomain_injective : Function.Injective evalDomain := by
+  intro i j h
+  rw [evalDomain_eq_getElem!, evalDomain_eq_getElem!] at h
+  exact Fin.ext (getElem_rootsOfUnityBrp_inj field_elements_per_blob_eq_two_pow
+    field_elements_per_blob_dvd_modulus_sub_one i.isLt j.isLt h)
+
+/-- Every domain point is a 4096th root of unity. -/
+theorem evalDomain_pow_width (i : Fin FIELD_ELEMENTS_PER_BLOB) :
+    evalDomain i ^ FIELD_ELEMENTS_PER_BLOB = 1 := by
+  rw [← mem_rootsOfUnityBrp field_elements_per_blob_eq_two_pow
+    field_elements_per_blob_dvd_modulus_sub_one]
+  exact Array.mem_iff_getElem.mpr ⟨i.val, _, rfl⟩
+
+/-- The nodal (vanishing) polynomial of the evaluation domain is
+`X^4096 − 1`: the domain enumerates exactly the 4096th roots of unity.
+Proved by comparing degrees, leading coefficients, and values at the
+4096 distinct nodes (both sides vanish there). -/
+theorem nodal_evalDomain :
+    Lagrange.nodal Finset.univ evalDomain
+      = X ^ FIELD_ELEMENTS_PER_BLOB - 1 := by
+  apply Polynomial.eq_of_degree_le_of_eval_index_eq Finset.univ
+    (Function.Injective.injOn evalDomain_injective)
+  · simp [Lagrange.degree_nodal]
+  · rw [← C_1, degree_X_pow_sub_C (by decide : 0 < FIELD_ELEMENTS_PER_BLOB)]
+    simp [Lagrange.degree_nodal]
+  · rw [Lagrange.nodal_monic.leadingCoeff, ← C_1,
+      (monic_X_pow_sub_C 1
+        (by decide : FIELD_ELEMENTS_PER_BLOB ≠ 0)).leadingCoeff]
+  · intro i _
+    rw [Lagrange.eval_nodal_at_node (Finset.mem_univ i),
+        eval_sub, eval_pow, eval_X, eval_one]
+    exact (sub_eq_zero_of_eq (evalDomain_pow_width i)).symm
+
+/-- The barycentric weight of node `i` is `D[i]/4096`: the weight is
+`(nodal'(D[i]))⁻¹`, the derivative of `X^4096 − 1` is `4096·X^4095`,
+and `D[i]^4095 = D[i]⁻¹` since `D[i]^4096 = 1`. -/
+theorem nodalWeight_evalDomain (i : Fin FIELD_ELEMENTS_PER_BLOB) :
+    Lagrange.nodalWeight Finset.univ evalDomain i
+      = evalDomain i * ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr)⁻¹ := by
+  rw [Lagrange.nodalWeight_eq_eval_derivative_nodal (Finset.mem_univ i),
+      nodal_evalDomain, derivative_sub, derivative_one, derivative_X_pow,
+      sub_zero, eval_mul, eval_pow, eval_X, eval_C]
+  have hvpow : evalDomain i ^ (FIELD_ELEMENTS_PER_BLOB - 1)
+      = (evalDomain i)⁻¹ := by
+    apply eq_inv_of_mul_eq_one_left
+    rw [← pow_succ,
+      show FIELD_ELEMENTS_PER_BLOB - 1 + 1 = FIELD_ELEMENTS_PER_BLOB by decide]
+    exact evalDomain_pow_width i
+  rw [mul_inv, hvpow, inv_inv, mul_comm]
+  rfl
+
+/-- Pure commutativity shuffle used in the slow-path sum below. Stated
+over variables so it can be applied with `exact` (which is robust
+against the `Fin`-vs-Mathlib instance-path mismatches that break
+`ring` on `Fr` goals). -/
+private theorem mul_shuffle (a b c q : Fr) :
+    a * c * b * q = q * a * b * c := by
+  rw [mul_comm, ← mul_assoc, ← mul_assoc, mul_right_comm]
+
+/-- A domain miss means `z` is none of the interpolation nodes. -/
+theorem ne_evalDomain_of_idxOf?_eq_none {z : Fr}
+    (h : (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB).idxOf? z = none)
+    (j : Fin FIELD_ELEMENTS_PER_BLOB) : z ≠ evalDomain j := by
+  intro heq
+  have hsz : j.val < (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB).size := by
+    rw [size_rootsOfUnityBrp]; exact j.isLt
+  have hmem : evalDomain j ∈ rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB :=
+    Array.mem_iff_getElem.mpr ⟨j.val, hsz, rfl⟩
+  rw [← heq] at hmem
+  exact Array.idxOf?_eq_none_iff.mp h hmem
+
+/-- **Correctness of `evaluatePolynomialInEvaluationForm`** (Lagrange
+form): for a full-width polynomial in evaluation form, the function
+computes the evaluation at `z` of the Lagrange interpolant of the
+pairs `(D[i], p[i])` over the bit-reversed roots-of-unity domain `D`.
+
+Together with interpolation uniqueness this pins the function down
+completely; see `evaluatePolynomialInEvaluationForm_eq_eval` for the
+statement in terms of an interpolated polynomial. -/
+theorem evaluatePolynomialInEvaluationForm_eq_interpolate
+    (p : Polynomial) (z : Fr) (hsize : p.size = FIELD_ELEMENTS_PER_BLOB) :
+    evaluatePolynomialInEvaluationForm p z
+      = Polynomial.eval z ((Lagrange.interpolate Finset.univ evalDomain)
+          fun i => p[i.val]!) := by
+  cases hidx : (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB).idxOf? z with
+  | some i =>
+    -- Fast path: `z = D[i]`, and the interpolant evaluates to `p[i]`
+    -- at its `i`-th node.
+    obtain ⟨hi, hz⟩ := idxOf?_rootsOfUnityBrp_eq_some hidx
+    rw [evaluatePolynomialInEvaluationForm_fastPath p z i hidx]
+    have hz' : evalDomain ⟨i, hi⟩ = z := by
+      rw [evalDomain_eq_getElem!]; exact hz
+    rw [← hz', Lagrange.eval_interpolate_at_node _
+      evalDomain_injective.injOn (Finset.mem_univ ⟨i, hi⟩)]
+  | none =>
+    -- Slow path: barycentric formula on both sides.
+    rw [evaluatePolynomialInEvaluationForm_slowPath_sum p z hsize hidx,
+        Lagrange.eval_interpolate_not_at_node _
+          (fun j _ => ne_evalDomain_of_idxOf?_eq_none hidx j)]
+    have hnodal : Polynomial.eval z (Lagrange.nodal Finset.univ evalDomain)
+        = z ^ FIELD_ELEMENTS_PER_BLOB - 1 := by
+      rw [nodal_evalDomain, eval_sub, eval_pow, eval_X, eval_one]
+      rfl
+    have hsum : ∑ j : Fin FIELD_ELEMENTS_PER_BLOB,
+          Lagrange.nodalWeight Finset.univ evalDomain j
+            * (z - evalDomain j)⁻¹ * p[j.val]!
+        = (∑ i ∈ Finset.range FIELD_ELEMENTS_PER_BLOB,
+            p[i]! * (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!
+              * (z - (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!)⁻¹)
+          * ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr)⁻¹ := by
+      rw [← Fin.sum_univ_eq_sum_range, Finset.sum_mul]
+      refine Finset.sum_congr rfl fun j _ => ?_
+      rw [nodalWeight_evalDomain j, evalDomain_eq_getElem!]
+      exact mul_shuffle _ _ _ _
+    calc (∑ i ∈ Finset.range FIELD_ELEMENTS_PER_BLOB,
+            p[i]! * (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!
+              * (z - (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!)⁻¹)
+          * (z ^ FIELD_ELEMENTS_PER_BLOB - 1)
+          * ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr)⁻¹
+        = (z ^ FIELD_ELEMENTS_PER_BLOB - 1)
+            * ((∑ i ∈ Finset.range FIELD_ELEMENTS_PER_BLOB,
+                p[i]! * (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!
+                  * (z - (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!)⁻¹)
+              * ((FIELD_ELEMENTS_PER_BLOB : Nat) : Fr)⁻¹) := by
+          rw [mul_right_comm]
+          exact mul_comm _ _
+      _ = Polynomial.eval z (Lagrange.nodal Finset.univ evalDomain)
+            * ∑ j : Fin FIELD_ELEMENTS_PER_BLOB,
+                Lagrange.nodalWeight Finset.univ evalDomain j
+                  * (z - evalDomain j)⁻¹ * p[j.val]! :=
+          (congrArg₂ (· * ·) hnodal hsum).symm
+
+/-- **Correctness of `evaluatePolynomialInEvaluationForm`** (spec
+voice): if the blob's field elements are the evaluations of a
+polynomial `f` of degree `< 4096` over the bit-reversed
+roots-of-unity domain, then the function returns `f(z)` — for *any*
+`z : Fr`, whether inside or outside the domain. `f` is unique by
+interpolation, so this characterizes the function completely. -/
+theorem evaluatePolynomialInEvaluationForm_eq_eval
+    (p : Polynomial) (f : _root_.Polynomial Fr) (z : Fr)
+    (hsize : p.size = FIELD_ELEMENTS_PER_BLOB)
+    (hdeg : f.degree < FIELD_ELEMENTS_PER_BLOB)
+    (hp : ∀ i, i < FIELD_ELEMENTS_PER_BLOB →
+      p[i]! = f.eval (rootsOfUnityBrp FIELD_ELEMENTS_PER_BLOB)[i]!) :
+    evaluatePolynomialInEvaluationForm p z = f.eval z := by
+  rw [evaluatePolynomialInEvaluationForm_eq_interpolate p z hsize]
+  have hf : f = (Lagrange.interpolate Finset.univ evalDomain)
+      fun i => p[i.val]! := by
+    refine Lagrange.eq_interpolate_of_eval_eq _ evalDomain_injective.injOn
+      (by simpa using hdeg) fun i _ => ?_
+    rw [hp i.val i.isLt, evalDomain_eq_getElem!]
+  rw [← hf]
+
+end EthCryptographySpecs.Kzg


### PR DESCRIPTION
This PR proves two important theorems about `evaluatePolynomialInEvaluationForm`:

### 1. `evaluatePolynomialInEvaluationForm_eq_interpolate`

    evaluatePolynomialInEvaluationForm p z
      = eval z (Lagrange.interpolate univ evalDomain (fun i => p[i]!))

for every `p` with `p.size = 4096` and every `z : Fr`.

### 2. `evaluatePolynomialInEvaluationForm_eq_eval`

    f.degree < 4096  →  (∀ i < 4096, p[i]! = f.eval D[i]!)
      →  evaluatePolynomialInEvaluationForm p z = f.eval z

Corollary of the first theorem, using uniqueness of interpolation.

The theorems are proven in `EthCryptographySpecs/Proofs/Kzg/Evaluation.lean`.

Sub-tasks that are also contained and were needed for this:
- Prove some more facts about `Fr` (EthCryptographySpecs/Proofs/Bls/FrZMod.lean)
- Prove properties of the evaluation domain (EthCryptographySpecs/Proofs/Kzg/Domain.lean)
- Equivalent mathlib variant of `evaluatePolynomialInEvaluationForm`  (EthCryptographySpecs/Proofs/Kzg/Barycentric.lean)